### PR TITLE
Update for cleaner use with Arduino

### DIFF
--- a/examples/TeensyRobustModuleLogger/TeensyRobustModuleLogger.ino
+++ b/examples/TeensyRobustModuleLogger/TeensyRobustModuleLogger.ino
@@ -1,3 +1,5 @@
+#define NO_PRAGMA_MARK
+
 #include "TeensyRobustModuleLogger.h"
 
 // NOTE that module APIs are not routed to the global instance manager,

--- a/examples/TeensySDLogger/TeensySDLogger.ino
+++ b/examples/TeensySDLogger/TeensySDLogger.ino
@@ -1,3 +1,5 @@
+#define NO_PRAGMA_MARK
+
 #include "TeensySDLogger.h"
 
 static TeensySDLogger Log;

--- a/examples/TeensySDRotationalLogger/TeensySDRotationalLogger.ino
+++ b/examples/TeensySDRotationalLogger/TeensySDRotationalLogger.ino
@@ -1,3 +1,5 @@
+#define NO_PRAGMA_MARK
+
 #include "TeensySDRotationalLogger.h"
 
 static TeensySDRotationalLogger Log;

--- a/examples/TeensySDRotationalLoggerModules/TeensySDRotationalLoggerModules.ino
+++ b/examples/TeensySDRotationalLoggerModules/TeensySDRotationalLoggerModules.ino
@@ -1,3 +1,5 @@
+#define NO_PRAGMA_MARK
+
 #include "TeensySDRotationalModuleLogger.h"
 
 // NOTE that module APIs are not routed to the global instance manager,

--- a/src/ArduinoLogger.h
+++ b/src/ArduinoLogger.h
@@ -74,7 +74,9 @@
 	}
 #endif
 
+#ifndef NO_PRAGMA_MARK
 #pragma mark - Short File Name Macro -
+#endif
 
 using cstr = const char* const;
 
@@ -96,7 +98,9 @@ constexpr cstr past_last_slash(cstr str)
 		sf__;                                           \
 	})
 
+#ifndef NO_PRAGMA_MARK
 #pragma mark - Tracing Macros -
+#endif
 
 #define STRINGPASTE(x) #x
 #define TOSTRING(x) STRINGPASTE(x)
@@ -109,7 +113,9 @@ constexpr cstr past_last_slash(cstr str)
 #define FUNC() __FUNCTION__
 #define PRETTY_FUNC() __PRETTY_FUNCTION__
 
+#ifndef NO_PRAGMA_MARK
 #pragma mark - Logging Class -
+#endif
 
 enum log_level_e
 {


### PR DESCRIPTION
Here are proposed changes which allow the suppression of spurious #PRAGMA warnings when compiling using the Arduino IDE.